### PR TITLE
Fix deploy action

### DIFF
--- a/.github/workflows/cancel_dupes.yml
+++ b/.github/workflows/cancel_dupes.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cancel-duplicate-workflow-runs:
     name: "Cancel duplicate workflow runs"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: potiuk/cancel-workflow-runs@master
         name: "Cancel duplicate workflow runs"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,13 +51,13 @@ jobs:
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
-      # Log into docker hub (so we can push images)
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # # Log into docker hub (so we can push images)
+      # -
+      #   name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Set up buildx for multi platform builds
       -
@@ -176,13 +176,13 @@ jobs:
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
-      # Log into docker hub (so we can push images)
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # # Log into docker hub (so we can push images)
+      # -
+      #   name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Set up buildx for multi platform builds
       -

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,8 @@ on:
       - main
 
   # Build and deploy the image nightly (to ensure we pick up any security updates)
-  # schedule:
-  #   - cron: "0 10 * * *"
+  schedule:
+    - cron: "0 10 * * *"
 
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
     env:
       REPO: kx1t
       IMAGE: planefence
-      PUSH: false
+      PUSH: true
     
     steps:
 
@@ -52,12 +52,12 @@ jobs:
         uses: docker/setup-qemu-action@v1
 
       # # Log into docker hub (so we can push images)
-      # -
-      #   name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Set up buildx for multi platform builds
       -
@@ -80,9 +80,9 @@ jobs:
       # Get version from "latest"
       -
         name: Get latest image version
-        run: echo VERSION_TAG=TEST >> $GITHUB_ENV
-          # docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest"
-          # echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest" /CONTAINER_VERSION)" >> $GITHUB_ENV
+        run: |
+          docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest"
+          echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest" /CONTAINER_VERSION)" >> $GITHUB_ENV
 
       # Show version from "latest"
       -
@@ -149,7 +149,7 @@ jobs:
     env:
       REPO: kx1t
       IMAGE: planefence
-      PUSH: false
+      PUSH: true
 
     steps:
 
@@ -177,12 +177,12 @@ jobs:
         uses: docker/setup-qemu-action@v1
 
       # # Log into docker hub (so we can push images)
-      # -
-      #   name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Set up buildx for multi platform builds
       -
@@ -217,9 +217,9 @@ jobs:
       # Get version from "latest"
       -
         name: Get latest image version
-        run: echo VERSION_TAG=TEST >> $GITHUB_ENV
-          # docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}"
-          # echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}" /CONTAINER_VERSION)" >> $GITHUB_ENV
+        run: |
+          docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}"
+          echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}" /CONTAINER_VERSION)" >> $GITHUB_ENV
 
       # Show version from "latest"
       -

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
       # Get version from "latest"
       -
         name: Get latest image version
-        run: echo TEST >> $GITHUB_ENV
+        run: echo VERSION_TAG=TEST >> $GITHUB_ENV
           # docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest"
           # echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest" /CONTAINER_VERSION)" >> $GITHUB_ENV
 
@@ -217,7 +217,7 @@ jobs:
       # Get version from "latest"
       -
         name: Get latest image version
-        run: echo TEST >> $GITHUB_ENV
+        run: echo VERSION_TAG=TEST >> $GITHUB_ENV
           # docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}"
           # echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}" /CONTAINER_VERSION)" >> $GITHUB_ENV
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   deploy_dockerhub_multiarch:
     name: Deploy to DockerHub (Multi-Arch)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     # Set job-wide environment variables
     #  - REPO: repo name on dockerhub
@@ -133,7 +133,7 @@ jobs:
 
   deploy_dockerhub_single_arch:
     name: Deploy to DockerHub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         docker-platform:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ on:
   # schedule:
   #   - cron: "0 10 * * *"
 
+
 jobs:
   deploy_dockerhub_multiarch:
     name: Deploy to DockerHub (Multi-Arch)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,9 +80,9 @@ jobs:
       # Get version from "latest"
       -
         name: Get latest image version
-        run: |
-          docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest"
-          echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest" /CONTAINER_VERSION)" >> $GITHUB_ENV
+        run: echo TEST >> $GITHUB_ENV
+          # docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest"
+          # echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest" /CONTAINER_VERSION)" >> $GITHUB_ENV
 
       # Show version from "latest"
       -
@@ -217,9 +217,9 @@ jobs:
       # Get version from "latest"
       -
         name: Get latest image version
-        run: |
-          docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}"
-          echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}" /CONTAINER_VERSION)" >> $GITHUB_ENV
+        run: echo TEST >> $GITHUB_ENV
+          # docker pull "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}"
+          # echo "VERSION_TAG=$(docker run --rm --entrypoint cat "${{ env.REPO }}/${{ env.IMAGE }}:latest_${{ env.ARCH_TAG }}" /CONTAINER_VERSION)" >> $GITHUB_ENV
 
       # Show version from "latest"
       -

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,8 @@ on:
       - main
 
   # Build and deploy the image nightly (to ensure we pick up any security updates)
-  schedule:
-    - cron: "0 10 * * *"
+  # schedule:
+  #   - cron: "0 10 * * *"
 
 jobs:
   deploy_dockerhub_multiarch:
@@ -23,7 +23,7 @@ jobs:
     env:
       REPO: kx1t
       IMAGE: planefence
-      PUSH: true
+      PUSH: false
     
     steps:
 
@@ -148,7 +148,7 @@ jobs:
     env:
       REPO: kx1t
       IMAGE: planefence
-      PUSH: true
+      PUSH: false
 
     steps:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,10 @@ RUN set -x && \
     # Install packages.
     #
     # first fix the file locations for a few files. This is needed for the amd64 image to build correctly
-    mkdir -p /usr/sbin/ && \
-    ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split && \
-    ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb && \
-    ln -s /bin/tar /usr/sbin/tar && \ 
+    # mkdir -p /usr/sbin/ && \
+    # ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split && \
+    # ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb && \
+    # ln -s /bin/tar /usr/sbin/tar && \ 
     # now go on with the actual install:
     apt-get update && \
     apt-get install -o APT::Autoremove::RecommendsImportant=0 -o APT::Autoremove::SuggestsImportant=0 -o Dpkg::Options::="--force-confold" --force-yes -y --no-install-recommends  --no-install-suggests\

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,8 +103,6 @@ RUN set -x && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/* /etc/services.d/planefence/.blank /etc/services.d/socket30003/.blank /run/socket30003/install-*
     # rm -rf /git/*
 
-
-
 COPY rootfs/ /
 
 ENTRYPOINT [ "/init" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,6 @@ RUN set -x && \
     #
     # Install packages.
     #
-    # first fix the file locations for a few files. This is needed for the amd64 image to build correctly
-    # mkdir -p /usr/sbin/ && \
-    # ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split && \
-    # ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb && \
-    # ln -s /bin/tar /usr/sbin/tar && \ 
-    # now go on with the actual install:
     apt-get update && \
     apt-get install -o APT::Autoremove::RecommendsImportant=0 -o APT::Autoremove::SuggestsImportant=0 -o Dpkg::Options::="--force-confold" --force-yes -y --no-install-recommends  --no-install-suggests\
         ${KEPT_PACKAGES[@]} \
@@ -112,6 +106,3 @@ ENTRYPOINT [ "/init" ]
 
 EXPOSE 80
 EXPOSE 30003
-
-# Add healthcheck
-HEALTHCHECK --start-period=3600s --interval=600s CMD /scripts/healthcheck.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Copy needs to be here to prevent github actions from failing.
+# SSL Certs are pre-loaded into the rootfs via a job in github action:
+# See: "Copy CA Certificates from GitHub Runner to Image rootfs" in deploy.yml
+COPY rootfs/ /
+
 RUN set -x && \
     TEMP_PACKAGES=() && \
     KEPT_PACKAGES=() && \
@@ -102,8 +107,6 @@ RUN set -x && \
     apt-get clean -y && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/* /etc/services.d/planefence/.blank /etc/services.d/socket30003/.blank /run/socket30003/install-*
     # rm -rf /git/*
-
-COPY rootfs/ /
 
 ENTRYPOINT [ "/init" ]
 


### PR DESCRIPTION
Hi @kx1t,

- Moved the `COPY` directive up to the top of the Dockerfile. I know this will make local builds slower... Have a look at @fredclausen's repo - he has a little shell script that will move the `COPY` command to the bottom to speed up local builds. As part of the deploy action, there's a step that will put CA certificates into the root filesystem of the container. This prevents the SSL errors on the ARM builds.
- Pin the github runner containers to `ubuntu-18.04`, as this seems to be more stable than `ubuntu-latest`, which has been recently updated to version 20 by github.
- Remove the symlink hacks, as they don't seem to be needed now. Unsure if this is because upstream has fixed the problem, or one of the items above has fixed it. 
- Removed the `HEALTHCHECK` directive from the Dockerfile, as the script it was pointing to didn't exist.

I would suggest a "Squash Merge", as this will squash the many commits below into one. :-)

-Mike