### PR TITLE
Change TWITTEXT from "PlaneAlert: " to "#PlaneAlert "

### DIFF
--- a/rootfs/usr/share/plane-alert/plane-alert.sh
+++ b/rootfs/usr/share/plane-alert/plane-alert.sh
@@ -293,7 +293,7 @@ then
 		# 0-ICAO,1-TailNr,2-Owner,3-PlaneDescription,4-date,5-time,6-lat,7-lon
 		# 8-callsign,9-adsbx_url,10-squawk
 
-		TWITTEXT="Plane Alert: "
+		TWITTEXT="#PlaneAlert "
 		TWITTEXT+="ICAO: ${pa_record[0]} "
 		[[ "${pa_record[1]}" != "" ]] && TWITTEXT+="Tail: ${pa_record[1]} "
 		[[ "${pa_record[8]}" != "" ]] && TWITTEXT+="Flt: ${pa_record[8]} "


### PR DESCRIPTION
As planefence is able to add a #planefence hashtag to every tweet, I propose plane-alert should to the same. That gives an easier access to all tweeted planealerts.
This adds the feature with some very basic changes only.