### PR TITLE
Discord Notifications - Timezones and Screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,4 @@ rootfs/webapp/static/images/30days.png
 rootfs/webapp/static/images/6hour.png
 ./acars-decoder-typescript.tgz
 acars-decoder-typescript.tgz
-rootfs/usr/lib/python3.7/pflib/__pycache__
+rootfs/usr/lib/python3/dist-packages/pflib/__pycache__

--- a/rootfs/usr/lib/python3/dist-packages/pflib/__init__.py
+++ b/rootfs/usr/lib/python3/dist-packages/pflib/__init__.py
@@ -177,7 +177,7 @@ def is_emergency(squawk):
 
 def attach_media(config, subsystem, webhook, embed):
     if config.get('DISCORD_MEDIA', "") == "screenshot":
-        snapshot_prefix = subsystem.lower() if subsystem.lower() == "pa" else ""
+        snapshot_prefix = "" if subsystem.lower() == "pf" else subsystem.lower()
         snapshot_path = f"/tmp/{snapshot_prefix}snapshot.png"
         testmsg(f"snapshot_path: {snapshot_path}")
         if exists(snapshot_path):

--- a/rootfs/usr/lib/python3/dist-packages/pflib/__init__.py
+++ b/rootfs/usr/lib/python3/dist-packages/pflib/__init__.py
@@ -27,6 +27,7 @@ import shutil
 import csv
 from datetime import datetime
 from os.path import exists
+import tzlocal
 
 import requests
 import discord_webhook as dw
@@ -180,13 +181,12 @@ def distance_unit(config):
         return "m"
     return "mi"
 
+def get_timezone_str():
+    return datetime.now(tzlocal.get_localzone()).strftime('%Z')
+
 def flightaware_link(icao, tail_num):
-    icao = icao.strip()
-    icao = icao.replace("[", "")
-    icao = icao.replace("]", "")
-    tail_num = tail_num.strip()
-    tail_num = tail_num.replace("[", "")
-    tail_num = tail_num.replace("]", "")
+    icao = icao.strip().replace("[", "").replace("]", "")
+    tail_num = tail_num.strip().replace("[", "").replace("]", "")
     return f"https://flightaware.com/live/modes/{icao}/ident/{tail_num}/redirect"
 
 def is_emergency(squawk):

--- a/rootfs/usr/share/plane-alert/plane-alert.sh
+++ b/rootfs/usr/share/plane-alert/plane-alert.sh
@@ -288,6 +288,14 @@ comm -23 <(sort < "$OUTFILE") <(sort < /tmp/pa-old.csv ) >/tmp/pa-diff.csv
 # If there's any new alerts send them out
 if [[ "$(cat /tmp/pa-diff.csv | wc -l)" != "0" ]]
 then
+	# Get a screenshot if there\'s one available!
+	rm -f /tmp/pasnapshot.png
+	GOTSNAP="false"
+	if curl -L -s --max-time $SCREENSHOT_TIMEOUT --fail $SCREENSHOTURL/snap/${pa_record[0]#\#} -o "/tmp/pasnapshot.png"
+	then
+		GOTSNAP="true"
+	fi
+
 	# Send Discord alerts if that's enabled
 	if [[ "${PA_DISCORD,,}" != "false" ]] && [[ "x$PA_DISCORD_WEBHOOKS" != "x" ]] && [[ "x$DISCORD_FEEDER_NAME" != "x" ]]
 	then
@@ -368,10 +376,9 @@ then
 					echo Tweeting with the following data: recipient = \"$twitterid\" Tweet DM = \"$TWITTEXT\"
 					[[ "$twitterid" == "" ]] && continue
 
-					# Get a screenshot if there\'s one available!
-					rm -f /tmp/pasnapshot.png
+					# Upload a screenshot if there\'s one available!
 					TWIMG="false"
-					if curl -L -s --max-time $SCREENSHOT_TIMEOUT --fail $SCREENSHOTURL/snap/${pa_record[0]#\#} -o "/tmp/pasnapshot.png"
+					if [[ "$GOTSNAP" == "true" ]]
 					then
 						# If the curl call succeeded, we have a snapshot.png file saved!
 						TW_MEDIA_ID=$(twurl -X POST -H upload.twitter.com "/1.1/media/upload.json" -f /tmp/pasnapshot.png -F media | sed -n 's/.*\"media_id\":\([0-9]*\).*/\1/p')

--- a/rootfs/usr/share/plane-alert/plane-alert.sh
+++ b/rootfs/usr/share/plane-alert/plane-alert.sh
@@ -294,6 +294,9 @@ then
 	if curl -L -s --max-time $SCREENSHOT_TIMEOUT --fail $SCREENSHOTURL/snap/${pa_record[0]#\#} -o "/tmp/pasnapshot.png"
 	then
 		GOTSNAP="true"
+		echo "Screenshot successfully retrieved at $SCREENSHOTURL for ${pa_record[0]}"
+	else
+		echo "Screenshot retrieval unsuccessful at $SCREENSHOTURL for ${pa_record[0]}"
 	fi
 
 	# Send Discord alerts if that's enabled
@@ -388,7 +391,8 @@ then
 						#	TW_MEDIA_ID=$(twurl -X POST -H upload.twitter.com "/1.1/media/upload.json" -f /tmp/test.png -F media | sed -n 's/.*\"media_id\":\([0-9]*\).*/\1/p')
 						#	[[ "$TW_MEDIA_ID" > 0 ]] && TWIMG="true" || TW_MEDIA_ID=""
 					fi
-					[[ "$TWIMG" == "true" ]] && echo "Screenshot successfully retrieved at $SCREENSHOTURL for ${pa_record[0]}; Twitter Media ID=$TW_MEDIA_ID" || echo "Screenshot retrieval unsuccessful at $SCREENSHOTURL for ${pa_record[0]}"
+					[[ "$TWIMG" == "true" ]] && echo "Twitter Media ID=$TW_MEDIA_ID" || echo "Twitter screenshot upload unsuccessful for ${pa_record[0]}"
+
 
 					# send a tweet.
 					# the conditional makes sure that tweets can be sent with or without image:

--- a/rootfs/usr/share/plane-alert/send-discord-alert.py
+++ b/rootfs/usr/share/plane-alert/send-discord-alert.py
@@ -92,6 +92,9 @@ def process_alerts(config, alerts):
         if plane.get('callsign', "") != "":
             pf.embed.field(embed, "Callsign", plane['callsign'])
 
+        if plane.get('time', "") != "":
+            pf.embed.field(embed, "First Seen", f"{plane['time']} {pf.get_timezone_str()}")
+
         if dbinfo.get('category', "") != "":
             pf.embed.field(embed, "Category", dbinfo['category'])
 

--- a/rootfs/usr/share/plane-alert/send-discord-alert.py
+++ b/rootfs/usr/share/plane-alert/send-discord-alert.py
@@ -110,13 +110,8 @@ def process_alerts(config, alerts):
         if dbinfo.get('link', "") != "":
             pf.embed.field(embed, "Link", f"[Learn More]({dbinfo['link']})")
 
-        # Get a screenshot to attach if configured
-        screenshot = None
-        if config.get("SCREENSHOTURL", "") != "":
-            screenshot = pf.get_screenshot_file(config, plane['icao'])
-
         # Send the message
-        pf.send(config['PA_DISCORD_WEBHOOKS'], embed)
+        pf.send(config, "PA", embed)
 
 
 def main():

--- a/rootfs/usr/share/planefence/planefence.conf
+++ b/rootfs/usr/share/planefence/planefence.conf
@@ -325,7 +325,7 @@
 
 # DISCORD_MEDIA controls what type of file attachment is sent to Discord
 #   If this is blank no media will be attached
-#   Set this to "screenshot" to attach a screenshot of tar1090 using the configured PF_SCREENSHOTURL
+#   Set this to "screenshot" to attach a screenshot of tar1090 using the configured SCREENSHOTURL
 #   TODO: Set this to "plane" to attach a photo of the plane if one is available
 	DISCORD_MEDIA=
 

--- a/rootfs/usr/share/planefence/planetweet.sh
+++ b/rootfs/usr/share/planefence/planetweet.sh
@@ -203,6 +203,14 @@ then
 			XX="@${RECORD[1]}"
 			RECORD[1]=$XX
 
+			# First, let's get a screenshot if there's one available!
+			rm -f /tmp/snapshot.png
+			GOTSNAP="false"
+			if curl -s -L --fail --max-time $SCREENSHOT_TIMEOUT $SCREENSHOTURL/snap/${RECORD[0]#\#} -o "/tmp/snapshot.png"
+			then
+				GOTSNAP="true"
+			fi
+
 			# LOG "PF_DISCORD: $PF_DISCORD"
 			# LOG "PF_DISCORD_WEBHOOKS: $PF_DISCORD_WEBHOOKS"
 			# LOG "DISCORD_FEEDER_NAME: $DISCORD_FEEDER_NAME"
@@ -219,7 +227,7 @@ then
 				# First, let's get a screenshot if there's one available!
 				rm -f /tmp/snapshot.png
 				TWIMG="false"
-				if curl -s -L --fail --max-time $SCREENSHOT_TIMEOUT $SCREENSHOTURL/snap/${RECORD[0]#\#} -o "/tmp/snapshot.png"
+				if [[ "$GOTSNAP" == "true" ]]
 				then
 					# If the curl call succeeded, we have a snapshot.png file saved!
 					TW_MEDIA_ID=$(twurl -X POST -H upload.twitter.com "/1.1/media/upload.json" -f /tmp/snapshot.png -F media | sed -n 's/.*\"media_id\":\([0-9]*\).*/\1/p')

--- a/rootfs/usr/share/planefence/planetweet.sh
+++ b/rootfs/usr/share/planefence/planetweet.sh
@@ -210,6 +210,7 @@ then
 			then
 				GOTSNAP="true"
 			fi
+			[[ "$GOTSNAP" == "true" ]] && echo "Screenshot successfully retrieved at $SCREENSHOTURL for ${RECORD[0]}" || echo "Screenshot retrieval unsuccessful at $SCREENSHOTURL for ${RECORD[0]}"
 
 			# LOG "PF_DISCORD: $PF_DISCORD"
 			# LOG "PF_DISCORD_WEBHOOKS: $PF_DISCORD_WEBHOOKS"
@@ -224,8 +225,6 @@ then
 			# And now, let's tweet!
 			if [ "$TWEETON" == "yes" ]
 			then
-				# First, let's get a screenshot if there's one available!
-				rm -f /tmp/snapshot.png
 				TWIMG="false"
 				if [[ "$GOTSNAP" == "true" ]]
 				then
@@ -234,7 +233,7 @@ then
 					[[ "$TW_MEDIA_ID" > 0 ]] && TWIMG="true" || TW_MEDIA_ID=""
 				fi
 
-				[[ "$TWIMG" == "true" ]] && echo "Screenshot successfully retrieved at $SCREENSHOTURL for ${RECORD[0]}; Twitter Media ID=$TW_MEDIA_ID" || echo "Screenshot retrieval unsuccessful at $SCREENSHOTURL for ${RECORD[0]}"
+				[[ "$TWIMG" == "true" ]] && echo "Twitter Media ID=$TW_MEDIA_ID" || echo "Twitter screenshot upload unsuccessful for ${RECORD[0]}"
 
 				# send a tweet and read the link to the tweet into ${LINK[1]}
 				if [[ "$TWIMG" == "true" ]]

--- a/rootfs/usr/share/planefence/prep-planefence.sh
+++ b/rootfs/usr/share/planefence/prep-planefence.sh
@@ -273,8 +273,7 @@ fi
 [[ "x$PF_DISCORD_WEBHOOKS" != "x" ]] && sed -i "s~\(^\s*PF_DISCORD_WEBHOOKS=\).*~\1${PF_DISCORD_WEBHOOKS}~" /usr/share/planefence/planefence.conf
 [[ "x$DISCORD_FEEDER_NAME" != "x" ]] && sed -i "s|\(^\s*DISCORD_FEEDER_NAME=\).*|\1\"${DISCORD_FEEDER_NAME}\"|" /usr/share/planefence/planefence.conf
 [[ "x$DISCORD_FEEDER_NAME" != "x" ]] && sed -i "s|\(^\s*DISCORD_FEEDER_NAME=\).*|\1\"${DISCORD_FEEDER_NAME}\"|" /usr/share/plane-alert/plane-alert.conf
-[[ "x$DISCORD_MEDIA" != "x" ]] && sed -i "s|\(^\s*$DISCORD_MEDIA=\).*|\1\"${$DISCORD_MEDIA}\"|" /usr/share/planefence/planefence.conf
-[[ "x$DISCORD_MEDIA" != "x" ]] && sed -i "s|\(^\s*$DISCORD_MEDIA=\).*|\1\"${$DISCORD_MEDIA}\"|" /usr/share/plane-alert/plane-alert.conf
+[[ "x$DISCORD_MEDIA" != "x" ]] && sed -i "s~\(^\s*DISCORD_MEDIA=\).*~\1${DISCORD_MEDIA}~" /usr/share/plane-alert/plane-alert.conf
 [[ "x$PF_NAME" != "x" ]] && sed -i 's|\(^\s*NAME=\).*|\1'"\"$PF_NAME\""'|' /usr/share/plane-alert/plane-alert.conf || sed -i 's|\(^\s*NAME=\).*|\1My|' /usr/share/plane-alert/plane-alert.conf
 [[ "x$PF_MAPURL" != "x" ]] && sed -i 's|\(^\s*ADSBLINK=\).*|\1'"\"$PF_MAPURL\""'|' /usr/share/plane-alert/plane-alert.conf
 # removed for now - hardcoding PlaneAlert map zoom to 7 in plane-alert.conf: [[ "x$PF_MAPZOOM" != "x" ]] && sed -i 's|\(^\s*MAPZOOM=\).*|\1'"\"$PF_MAPZOOM\""'|' /usr/share/plane-alert/plane-alert.conf

--- a/rootfs/usr/share/planefence/prep-planefence.sh
+++ b/rootfs/usr/share/planefence/prep-planefence.sh
@@ -274,6 +274,7 @@ fi
 [[ "x$DISCORD_FEEDER_NAME" != "x" ]] && sed -i "s|\(^\s*DISCORD_FEEDER_NAME=\).*|\1\"${DISCORD_FEEDER_NAME}\"|" /usr/share/planefence/planefence.conf
 [[ "x$DISCORD_FEEDER_NAME" != "x" ]] && sed -i "s|\(^\s*DISCORD_FEEDER_NAME=\).*|\1\"${DISCORD_FEEDER_NAME}\"|" /usr/share/plane-alert/plane-alert.conf
 [[ "x$DISCORD_MEDIA" != "x" ]] && sed -i "s~\(^\s*DISCORD_MEDIA=\).*~\1${DISCORD_MEDIA}~" /usr/share/plane-alert/plane-alert.conf
+[[ "x$DISCORD_MEDIA" != "x" ]] && sed -i "s~\(^\s*DISCORD_MEDIA=\).*~\1${DISCORD_MEDIA}~" /usr/share/planefence/planefence.conf
 [[ "x$PF_NAME" != "x" ]] && sed -i 's|\(^\s*NAME=\).*|\1'"\"$PF_NAME\""'|' /usr/share/plane-alert/plane-alert.conf || sed -i 's|\(^\s*NAME=\).*|\1My|' /usr/share/plane-alert/plane-alert.conf
 [[ "x$PF_MAPURL" != "x" ]] && sed -i 's|\(^\s*ADSBLINK=\).*|\1'"\"$PF_MAPURL\""'|' /usr/share/plane-alert/plane-alert.conf
 # removed for now - hardcoding PlaneAlert map zoom to 7 in plane-alert.conf: [[ "x$PF_MAPZOOM" != "x" ]] && sed -i 's|\(^\s*MAPZOOM=\).*|\1'"\"$PF_MAPZOOM\""'|' /usr/share/plane-alert/plane-alert.conf

--- a/rootfs/usr/share/planefence/prep-planefence.sh
+++ b/rootfs/usr/share/planefence/prep-planefence.sh
@@ -273,6 +273,8 @@ fi
 [[ "x$PF_DISCORD_WEBHOOKS" != "x" ]] && sed -i "s~\(^\s*PF_DISCORD_WEBHOOKS=\).*~\1${PF_DISCORD_WEBHOOKS}~" /usr/share/planefence/planefence.conf
 [[ "x$DISCORD_FEEDER_NAME" != "x" ]] && sed -i "s|\(^\s*DISCORD_FEEDER_NAME=\).*|\1\"${DISCORD_FEEDER_NAME}\"|" /usr/share/planefence/planefence.conf
 [[ "x$DISCORD_FEEDER_NAME" != "x" ]] && sed -i "s|\(^\s*DISCORD_FEEDER_NAME=\).*|\1\"${DISCORD_FEEDER_NAME}\"|" /usr/share/plane-alert/plane-alert.conf
+[[ "x$DISCORD_MEDIA" != "x" ]] && sed -i "s|\(^\s*$DISCORD_MEDIA=\).*|\1\"${$DISCORD_MEDIA}\"|" /usr/share/planefence/planefence.conf
+[[ "x$DISCORD_MEDIA" != "x" ]] && sed -i "s|\(^\s*$DISCORD_MEDIA=\).*|\1\"${$DISCORD_MEDIA}\"|" /usr/share/plane-alert/plane-alert.conf
 [[ "x$PF_NAME" != "x" ]] && sed -i 's|\(^\s*NAME=\).*|\1'"\"$PF_NAME\""'|' /usr/share/plane-alert/plane-alert.conf || sed -i 's|\(^\s*NAME=\).*|\1My|' /usr/share/plane-alert/plane-alert.conf
 [[ "x$PF_MAPURL" != "x" ]] && sed -i 's|\(^\s*ADSBLINK=\).*|\1'"\"$PF_MAPURL\""'|' /usr/share/plane-alert/plane-alert.conf
 # removed for now - hardcoding PlaneAlert map zoom to 7 in plane-alert.conf: [[ "x$PF_MAPZOOM" != "x" ]] && sed -i 's|\(^\s*MAPZOOM=\).*|\1'"\"$PF_MAPZOOM\""'|' /usr/share/plane-alert/plane-alert.conf

--- a/rootfs/usr/share/planefence/send-discord-alert.py
+++ b/rootfs/usr/share/planefence/send-discord-alert.py
@@ -77,7 +77,9 @@ def process_alert(config, plane):
     pf.embed.field(embed, "ICAO", plane['icao'])
     pf.embed.field(embed, "Tail Number", f"[{plane['tail_num']}]({fa_link})")
     pf.embed.field(embed, "Distance", f"{plane['min_dist']}{pf.distance_unit(config)}")
-    pf.embed.field(embed, "First Seen", plane['first_seen'].split(" ")[1])
+
+    time_seen = plane['first_seen'].split(" ")[1]
+    pf.embed.field(embed, "First Seen", f"{time_seen} {pf.get_timezone_str()}")
 
     # Get a screenshot to attach if configured
     screenshot = None

--- a/rootfs/usr/share/planefence/send-discord-alert.py
+++ b/rootfs/usr/share/planefence/send-discord-alert.py
@@ -87,7 +87,7 @@ def process_alert(config, plane):
         screenshot = pf.get_screenshot_file(config, plane['icao'])
 
     # Send the message
-    pf.send(config['PF_DISCORD_WEBHOOKS'], embed)
+    pf.send(config, "PF", embed)
 
 
 def main():


### PR DESCRIPTION
- Detect the local system's timezone and use that to attach the time zone's abbreviation to timestamps
- Add First Seen to Plane Alert messages

<img width="111" alt="image" src="https://user-images.githubusercontent.com/867375/151639719-a7c40528-c73c-42f9-a80c-89f8a87fe41e.png">

- If `DISCORD_MEDIA` is set to `screenshot` we'll use the same screenshot that's attached to twitter posts. Works with both Planefence and PlaneAlert
<img width="485" alt="image" src="https://user-images.githubusercontent.com/867375/151660715-802298c8-d723-4207-ac33-27446a48f597.png">