### PR TITLE
Discord plane photos

### DIFF
--- a/rootfs/usr/lib/python3/dist-packages/pflib/discord.py
+++ b/rootfs/usr/lib/python3/dist-packages/pflib/discord.py
@@ -1,11 +1,16 @@
-import discord_webhook as discord
+import discord_webhook as dw
 
-def build(title, description, color=None):
+def build(urls, title, description, color=None):
+    webhook = dw.DiscordWebhook(url=urls)
+
     if color is None:
         color = 0x007bff  # Blue
-    embed = discord.DiscordEmbed(title=title, color=color, description=description)
+    embed = dw.DiscordEmbed(title=title, color=color, description=description)
     embed.set_footer(text="Planefence by kx1t - docker:kx1t/planefence")
-    return embed
+
+    webhook.add_embed(embed)
+
+    return webhook, embed
 
 def field(embed, name, value, inline=None):
     if inline is None:

--- a/rootfs/usr/share/plane-alert/send-discord-alert.py
+++ b/rootfs/usr/share/plane-alert/send-discord-alert.py
@@ -80,38 +80,39 @@ def process_alerts(config, alerts):
             description = f"Operated by **{plane.get('owner')}**"
         description += f"\n[Track on ADS-B Exchange]({plane['adsbx_url']})"
 
-        embed = pf.embed.build(title, description, color=color)
+        webhook, embed = pf.discord.build(config["PA_DISCORD_WEBHOOKS"], title, description, color=color)
+        pf.attach_media(config, "PA", dbinfo, webhook, embed)
 
         if config.get("DISCORD_FEEDER_NAME", "") != "":
-            pf.embed.field(embed, "Feeder", config["DISCORD_FEEDER_NAME"])
+            pf.discord.field(embed, "Feeder", config["DISCORD_FEEDER_NAME"])
 
         # Attach data fields
-        pf.embed.field(embed, "ICAO", plane['icao'])
-        pf.embed.field(embed, "Tail Number", f"[{plane['tail_num']}]({fa_link})")
+        pf.discord.field(embed, "ICAO", plane['icao'])
+        pf.discord.field(embed, "Tail Number", f"[{plane['tail_num']}]({fa_link})")
 
         if plane.get('callsign', "") != "":
-            pf.embed.field(embed, "Callsign", plane['callsign'])
+            pf.discord.field(embed, "Callsign", plane['callsign'])
 
         if plane.get('time', "") != "":
-            pf.embed.field(embed, "First Seen", f"{plane['time']} {pf.get_timezone_str()}")
+            pf.discord.field(embed, "First Seen", f"{plane['time']} {pf.get_timezone_str()}")
 
         if dbinfo.get('category', "") != "":
-            pf.embed.field(embed, "Category", dbinfo['category'])
+            pf.discord.field(embed, "Category", dbinfo['category'])
 
         if dbinfo.get('tag1', "") != "":
-            pf.embed.field(embed, "Tag", dbinfo['tag1'])
+            pf.discord.field(embed, "Tag", dbinfo['tag1'])
 
         if dbinfo.get('tag2', "") != "":
-            pf.embed.field(embed, "Tag", dbinfo['tag2'])
+            pf.discord.field(embed, "Tag", dbinfo['tag2'])
 
         if dbinfo.get('tag3', "") != "":
-            pf.embed.field(embed, "Tag", dbinfo['tag3'])
+            pf.discord.field(embed, "Tag", dbinfo['tag3'])
 
         if dbinfo.get('link', "") != "":
-            pf.embed.field(embed, "Link", f"[Learn More]({dbinfo['link']})")
+            pf.discord.field(embed, "Link", f"[Learn More]({dbinfo['link']})")
 
         # Send the message
-        pf.send(config, "PA", embed)
+        webhook.execute()
 
 
 def main():

--- a/rootfs/usr/share/planefence/planefence.conf
+++ b/rootfs/usr/share/planefence/planefence.conf
@@ -325,8 +325,20 @@
 
 # DISCORD_MEDIA controls what type of file attachment is sent to Discord
 #   If this is blank no media will be attached
-#   Set this to "screenshot" to attach a screenshot of tar1090 using the configured SCREENSHOTURL
-#   TODO: Set this to "plane" to attach a photo of the plane if one is available
+#   "screenshot"
+#     Attach a screenshot of tar1090 using the configured SCREENSHOTURL
+#   "photo"
+#     Attach a photo of the plane if available. Only works for plane-alert
+#   "photo+screenshot"
+#     Plane-Alert:
+#       Attach the photo, if avaialble, as the main image and a screenshot as the thumbnail
+#     Planefence:
+#       Same as "screenshot"
+#    "screenshot+photo"
+#     Plane-Alert:
+#       Attach the screenshot as the main image and a photo, if available, as the thumbnail
+#     Planefence:
+#       Same as "screenshot"
 	DISCORD_MEDIA=
 
 # Last, the version. Although you could change this, for tracking purposes, we'd like you to leave it to whatever the

--- a/rootfs/usr/share/planefence/prep-planefence.sh
+++ b/rootfs/usr/share/planefence/prep-planefence.sh
@@ -15,6 +15,31 @@ PLANEFENCEDIR=/usr/share/planefence
 APPNAME="$(hostname)/planefence"
 REMOTEURL=$(sed -n 's/\(^\s*REMOTEURL=\)\(.*\)/\2/p' /usr/share/planefence/planefence.conf)
 
+function configure_planefence() {
+	local SETTING_NAME="$1"
+	local SETTING_VALUE="$2"
+	if [[ "x$SETTING_VALUE" != "x" ]]
+	then
+		sed -i "s~\(^\s*${SETTING_NAME}=\).*~\1${SETTING_VALUE}~" /usr/share/planefence/planefence.conf
+	else
+		sed -i "s|\(^\s*${SETTING_NAME}=\).*|\1|" /usr/share/planefence/planefence.conf
+	fi
+}
+function configure_planealert() {
+	local SETTING_NAME="$1"
+	local SETTING_VALUE="$2"
+	if [[ "x$SETTING_VALUE" != "x" ]]
+	then
+		sed -i "s~\(^\s*${SETTING_NAME}=\).*~\1${SETTING_VALUE}~" /usr/share/plane-alert/plane-alert.conf
+	else
+		sed -i "s|\(^\s*${SETTING_NAME}=\).*|\1|" /usr/share/plane-alert/plane-alert.conf
+	fi
+}
+function configure_both() {
+	configure_planefence "$1" "$2"
+	configure_planealert "$1" "$2"
+}
+
 [[ "$LOGLEVEL" != "ERROR" ]] && echo "[$APPNAME][$(date)] Running PlaneFence configuration - either the container is restarted or a config change was detected." || true
 # Sometimes, variables are passed in through .env in the Docker-compose directory
 # However, if there is a planefence.config file in the ..../persist directory
@@ -268,13 +293,10 @@ fi
 [[ "$PA_DISCORD" == "ON" ]] && sed -i 's|\(^\s*PA_DISCORD=\).*|\1true|' /usr/share/plane-alert/plane-alert.conf || sed -i 's|\(^\s*PA_DISCORD=\).*|\1false|' /usr/share/plane-alert/plane-alert.conf
 [[ "$PA_DISCORD" == "ON" ]] && sed -i 's|\(^\s*PA_DISCORD=\).*|\1true|' /usr/share/planefence/planefence.conf || sed -i 's|\(^\s*PA_DISCORD=\).*|\1false|' /usr/share/planefence/planefence.conf
 [[ "$PF_DISCORD" == "ON" ]] && sed -i 's|\(^\s*PF_DISCORD=\).*|\1true|' /usr/share/planefence/planefence.conf || sed -i 's|\(^\s*PF_DISCORD=\).*|\1false|' /usr/share/planefence/planefence.conf
-[[ "x$PA_DISCORD_WEBHOOKS" != "x" ]] && sed -i "s~\(^\s*PA_DISCORD_WEBHOOKS=\).*~\1${PA_DISCORD_WEBHOOKS}~" /usr/share/plane-alert/plane-alert.conf
-[[ "x$PA_DISCORD_WEBHOOKS" != "x" ]] && sed -i "s~\(^\s*PA_DISCORD_WEBHOOKS=\).*~\1${PA_DISCORD_WEBHOOKS}~" /usr/share/planefence/planefence.conf
-[[ "x$PF_DISCORD_WEBHOOKS" != "x" ]] && sed -i "s~\(^\s*PF_DISCORD_WEBHOOKS=\).*~\1${PF_DISCORD_WEBHOOKS}~" /usr/share/planefence/planefence.conf
-[[ "x$DISCORD_FEEDER_NAME" != "x" ]] && sed -i "s|\(^\s*DISCORD_FEEDER_NAME=\).*|\1\"${DISCORD_FEEDER_NAME}\"|" /usr/share/planefence/planefence.conf
-[[ "x$DISCORD_FEEDER_NAME" != "x" ]] && sed -i "s|\(^\s*DISCORD_FEEDER_NAME=\).*|\1\"${DISCORD_FEEDER_NAME}\"|" /usr/share/plane-alert/plane-alert.conf
-[[ "x$DISCORD_MEDIA" != "x" ]] && sed -i "s~\(^\s*DISCORD_MEDIA=\).*~\1${DISCORD_MEDIA}~" /usr/share/plane-alert/plane-alert.conf
-[[ "x$DISCORD_MEDIA" != "x" ]] && sed -i "s~\(^\s*DISCORD_MEDIA=\).*~\1${DISCORD_MEDIA}~" /usr/share/planefence/planefence.conf
+configure_planealert "PA_DISCORD_WEBHOOKS" "${PA_DISCORD_WEBHOOKS}"
+configure_planefence "PF_DISCORD_WEBHOOKS" "${PF_DISCORD_WEBHOOKS}"
+configure_both "DISCORD_FEEDER_NAME" "${DISCORD_FEEDER_NAME}"
+configure_both "DISCORD_MEDIA" "${DISCORD_MEDIA}"
 [[ "x$PF_NAME" != "x" ]] && sed -i 's|\(^\s*NAME=\).*|\1'"\"$PF_NAME\""'|' /usr/share/plane-alert/plane-alert.conf || sed -i 's|\(^\s*NAME=\).*|\1My|' /usr/share/plane-alert/plane-alert.conf
 [[ "x$PF_MAPURL" != "x" ]] && sed -i 's|\(^\s*ADSBLINK=\).*|\1'"\"$PF_MAPURL\""'|' /usr/share/plane-alert/plane-alert.conf
 # removed for now - hardcoding PlaneAlert map zoom to 7 in plane-alert.conf: [[ "x$PF_MAPZOOM" != "x" ]] && sed -i 's|\(^\s*MAPZOOM=\).*|\1'"\"$PF_MAPZOOM\""'|' /usr/share/plane-alert/plane-alert.conf

--- a/rootfs/usr/share/planefence/send-discord-alert.py
+++ b/rootfs/usr/share/planefence/send-discord-alert.py
@@ -66,28 +66,26 @@ def process_alert(config, plane):
 
     fa_link = pf.flightaware_link(plane['icao'], plane['tail_num'])
 
-    embed = pf.embed.build(
+    webhook, embed = pf.discord.build(
+        config["PA_DISCORD_WEBHOOKS"],
         f"{name} is overhead at {pf.altitude_str(config, plane['alt'])}",
         f"[Track on ADS-B Exchange]({plane['adsbx_url']})")
 
+    pf.attach_media(config, "PA", plane, webhook, embed)
+
     if config.get("DISCORD_FEEDER_NAME", "") != "":
-        pf.embed.field(embed, "Feeder", config["DISCORD_FEEDER_NAME"])
+        pf.discord.field(embed, "Feeder", config["DISCORD_FEEDER_NAME"])
 
     # Attach data fields
-    pf.embed.field(embed, "ICAO", plane['icao'])
-    pf.embed.field(embed, "Tail Number", f"[{plane['tail_num']}]({fa_link})")
-    pf.embed.field(embed, "Distance", f"{plane['min_dist']}{pf.distance_unit(config)}")
+    pf.discord.field(embed, "ICAO", plane['icao'])
+    pf.discord.field(embed, "Tail Number", f"[{plane['tail_num']}]({fa_link})")
+    pf.discord.field(embed, "Distance", f"{plane['min_dist']}{pf.distance_unit(config)}")
 
     time_seen = plane['first_seen'].split(" ")[1]
-    pf.embed.field(embed, "First Seen", f"{time_seen} {pf.get_timezone_str()}")
-
-    # Get a screenshot to attach if configured
-    screenshot = None
-    if config.get('SCREENSHOTURL') is not None:
-        screenshot = pf.get_screenshot_file(config, plane['icao'])
+    pf.discord.field(embed, "First Seen", f"{time_seen} {pf.get_timezone_str()}")
 
     # Send the message
-    pf.send(config, "PF", embed)
+    webhook.execute()
 
 
 def main():


### PR DESCRIPTION
@Sportsbadger added a new csv file to the plane-alert-db with images. This adds new `DISCORD_MEDIA` modes that can include photos of planes for PlaneAlert notifications.

To use the new list: In `~/.planefence/planefence.config` set:
```
PF_ALERTLIST=https://raw.githubusercontent.com/Sportsbadger/plane-alert-db/main/plane-alert-db-images.csv
```
And `DISCORD_MEDIA` supports the following modes now:
```
#   "screenshot"
#     Attach a screenshot of tar1090 using the configured SCREENSHOTURL
#   "photo"
#     Attach a photo of the plane if available. Only works for plane-alert
#   "photo+screenshot"
#     Plane-Alert:
#       Attach the photo, if avaialble, as the main image and a screenshot as the thumbnail
#     Planefence:
#       Same as "screenshot"
#    "screenshot+photo"
#     Plane-Alert:
#       Attach the screenshot as the main image and a photo, if available, as the thumbnail
#     Planefence:
#       Same as "screenshot"
```

Here's an example of a `photo+screenshot` PlaneAlert message:
<img width="573" alt="image" src="https://user-images.githubusercontent.com/867375/151796790-5faac253-748b-4c6f-aa43-3a2470210372.png">
If you click the map thumbnail it opens it up fullscreen. `screenshot+plane` flips which photo is the thumbnail.

