### PR TITLE
Set the webhook's username to the Feeder Name

### DIFF
--- a/rootfs/usr/lib/python3/dist-packages/pflib/discord.py
+++ b/rootfs/usr/lib/python3/dist-packages/pflib/discord.py
@@ -1,7 +1,7 @@
 import discord_webhook as dw
 
-def build(urls, title, description, color=None):
-    webhook = dw.DiscordWebhook(url=urls)
+def build(username, urls, title, description, color=None):
+    webhook = dw.DiscordWebhook(url=urls, username=username)
 
     if color is None:
         color = 0x007bff  # Blue

--- a/rootfs/usr/lib/python3/dist-packages/pflib/discord.py
+++ b/rootfs/usr/lib/python3/dist-packages/pflib/discord.py
@@ -1,6 +1,10 @@
 import discord_webhook as dw
 
 def build(username, urls, title, description, color=None):
+    # If the Feeder Name is a link pull out the text:
+    if '[' in username and ']' in username:
+        username = username.split('[')[1].split(']')[0]
+
     webhook = dw.DiscordWebhook(url=urls, username=username)
 
     if color is None:

--- a/rootfs/usr/share/plane-alert/send-discord-alert.py
+++ b/rootfs/usr/share/plane-alert/send-discord-alert.py
@@ -86,11 +86,8 @@ def process_alert(config, plane):
     else:
         description += f"\nSeen near [**{location}**]({plane['adsbx_url']})"
 
-    webhook, embed = pf.discord.build(config["PA_DISCORD_WEBHOOKS"], title, description, color=color)
+    webhook, embed = pf.discord.build(config["DISCORD_FEEDER_NAME"], config["PA_DISCORD_WEBHOOKS"], title, description, color=color)
     pf.attach_media(config, "PA", dbinfo, webhook, embed)
-
-    if config.get("DISCORD_FEEDER_NAME", "") != "":
-        pf.discord.field(embed, "Feeder", config["DISCORD_FEEDER_NAME"])
 
     # Attach data fields
     pf.discord.field(embed, "ICAO", plane['icao'])

--- a/rootfs/usr/share/planefence/send-discord-alert.py
+++ b/rootfs/usr/share/planefence/send-discord-alert.py
@@ -67,14 +67,12 @@ def process_alert(config, plane):
     fa_link = pf.flightaware_link(plane['icao'], plane['tail_num'])
 
     webhook, embed = pf.discord.build(
+        config["DISCORD_FEEDER_NAME"],
         config["PF_DISCORD_WEBHOOKS"],
         f"{name} is overhead at {pf.altitude_str(config, plane['alt'])}",
         f"[Track on ADS-B Exchange]({plane['adsbx_url']})")
 
     pf.attach_media(config, "PF", plane, webhook, embed)
-
-    if config.get("DISCORD_FEEDER_NAME", "") != "":
-        pf.discord.field(embed, "Feeder", config["DISCORD_FEEDER_NAME"])
 
     # Attach data fields
     pf.discord.field(embed, "ICAO", plane['icao'])


### PR DESCRIPTION
Removes the "Feeder" field from the notification and sets the webhook's username to the feeder name.

<img width="559" alt="image" src="https://user-images.githubusercontent.com/867375/156463980-96f3da17-3391-4775-81cc-8c818effc892.png">

If the configured feeder name is a markdown link like `[text](url)` we pull out just the text.