### PR TITLE
Additional detail in the planepix.txt log entry

### DIFF
--- a/rootfs/usr/share/planefence/prep-planefence.sh
+++ b/rootfs/usr/share/planefence/prep-planefence.sh
@@ -359,7 +359,7 @@ if curl -L -s https://raw.githubusercontent.com/sdr-enthusiasts/plane-alert-db/m
 then
 	chmod a+r /usr/share/planefence/persist/planepix.txt.samplefile
 	echo "[$APPNAME][$(date)] Successfully downloaded planepix sample file to ~/.planefence/planepix.txt.samplefile directory."
-	echo "[$APPNAME][$(date)] To use it, rename it to, or incorporate it into ~/.planefence/planepix.txt"
+	echo "[$APPNAME][$(date)] To use it, rename it to, or incorporate it into ~/.planefence/planepix.txt. Any entries in this file will replace the tar1090 screenshot."
 fi
 #--------------------------------------------------------------------------------
 # Put the MOTDs in place:

--- a/rootfs/usr/share/planefence/prep-planefence.sh
+++ b/rootfs/usr/share/planefence/prep-planefence.sh
@@ -359,7 +359,7 @@ if curl -L -s https://raw.githubusercontent.com/sdr-enthusiasts/plane-alert-db/m
 then
 	chmod a+r /usr/share/planefence/persist/planepix.txt.samplefile
 	echo "[$APPNAME][$(date)] Successfully downloaded planepix sample file to ~/.planefence/planepix.txt.samplefile directory."
-	echo "[$APPNAME][$(date)] To use it, rename it to, or incorporate it into ~/.planefence/planepix.txt. Any entries in this file will replace the tar1090 screenshot."
+	echo "[$APPNAME][$(date)] To use it, rename it to, or incorporate it into ~/.planefence/planepix.txt. Any entries in this file will replace the tar1090 screenshot with a picture of the plane."
 fi
 #--------------------------------------------------------------------------------
 # Put the MOTDs in place:


### PR DESCRIPTION
Adding additional details to planepix.txt log entry that hints that using the file will overwrite the expected behavior of screenshots being from tar1090. 