### PR TITLE
correct attribution link on plane alert page

### DIFF
--- a/rootfs/usr/share/plane-alert/plane-alert.footer.html
+++ b/rootfs/usr/share/plane-alert/plane-alert.footer.html
@@ -2,7 +2,7 @@
 
 <div class="footer">
 <hr/>Plane-Alert version ##VERSION## is part of <a href="https://github.com/kx1t/docker-planefence" target="_blank">KX1T's PlaneFence Open Source Project</a>, available under the GPLv3 license on <a href="https://github.com/kx1t/docker-planefence" target="_blank">Github</a> and on <a href="https://hub.docker.com/repository/docker/kx1t/planefence" target="_blank">docker:kx1t/docker-planefence</a>. Support is available on the #Planefence channel of the SDR Enthusiasts Discord Server. Click the Chat icon below to join.
-<br/>Build: ##BUILD##. &copy; Copyright 2020 - 2022 by Ram&oacute;n F. Kolb, kx1t. Please see <a href="attribution.txt" target="_blank">here</a> for attributions to our contributors and open source packages used.
+<br/>Build: ##BUILD##. &copy; Copyright 2020 - 2023 by Ram&oacute;n F. Kolb, kx1t. Please see <a href="../attribution.txt" target="_blank">here</a> for attributions to our contributors and open source packages used.
 <br/><a href="https://github.com/kx1t/docker-planefence" target="_blank"><img src="https://img.shields.io/github/actions/workflow/status/kx1t/docker-planefence/deploy.yml"></a>
 <a href="https://github.com/kx1t/docker-planefence" target="_blank"><img src="https://img.shields.io/docker/pulls/kx1t/planefence.svg"></a>
 <a href="https://github.com/kx1t/docker-planefence" target="_blank"><img src="https://img.shields.io/docker/image-size/kx1t/planefence/latest"></a>


### PR DESCRIPTION
Existing link points to attribution file that does not exist. Adjusted link path to point to Planefence attribution.