### PR TITLE
Fixing OpenAIP integration for Planefence heatmap

### DIFF
--- a/rootfs/usr/share/planefence/planefence.conf
+++ b/rootfs/usr/share/planefence/planefence.conf
@@ -293,6 +293,10 @@
 
 	OPENAIP_LAYER=OFF
 
+# OpenAIP API key, necessary if OPENAIP_LAYER is set to ON
+
+	OPENAIPKEY= 
+
 # TWEET_BEHAVIOR determines if a Planefence Tweet is sent after the initial observation or after the last observation within the Fence
 # Default: POST     Valid values: POST, PRE     Assumed value if omitted or "not PRE": POST
 

--- a/rootfs/usr/share/planefence/planeheat.sh
+++ b/rootfs/usr/share/planefence/planeheat.sh
@@ -348,8 +348,8 @@ EOF
 if [[ "$OPENAIP_LAYER" == "ON" ]]
 then
 	cat <<EOF >>"$PLANEHEATHTML"
-    var openaip_cached_basemap = new L.TileLayer("https://{s}.api.tiles.openaip.net/api/data/openaip/{z}/{x}/{y}.png?apiKey={OPENAIPKEY}").addTo(map);
-    
+    var openaip_cached_basemap = new L.TileLayer("https://{s}.api.tiles.openaip.net/api/data/openaip/{z}/{x}/{y}.png?apiKey={PF_OPENAIPKEY}").addTo(map);
+
 EOF
 fi
 cat <<EOF >>"$PLANEHEATHTML"

--- a/rootfs/usr/share/planefence/planeheat.sh
+++ b/rootfs/usr/share/planefence/planeheat.sh
@@ -348,16 +348,8 @@ EOF
 if [[ "$OPENAIP_LAYER" == "ON" ]]
 then
 	cat <<EOF >>"$PLANEHEATHTML"
-    var openaip_cached_basemap = new L.TileLayer("http://{s}.tile.maps.openaip.net/geowebcache/service/tms/1.0.0/openaip_basemap@EPSG%3A900913@png/{z}/{x}/{y}.png", {
-         maxZoom: 16,
-         minZoom: 2,
-         tms: true,
-         subdomains: '12',
-         format: 'image/png',
-         transparent: true,
-         attribution: "<a href=http://www.openaip.net>OpenAIP.net</a>"
-         }).addTo(map);
-
+    var openaip_cached_basemap = new L.TileLayer("https://{s}.api.tiles.openaip.net/api/data/openaip/{z}/{x}/{y}.png?apiKey={OPENAIPKEY}").addTo(map);
+    
 EOF
 fi
 cat <<EOF >>"$PLANEHEATHTML"

--- a/rootfs/usr/share/planefence/planeheat.sh
+++ b/rootfs/usr/share/planefence/planeheat.sh
@@ -348,7 +348,7 @@ EOF
 if [[ "$OPENAIP_LAYER" == "ON" ]]
 then
 	cat <<EOF >>"$PLANEHEATHTML"
-    var openaip_cached_basemap = new L.TileLayer("https://{s}.api.tiles.openaip.net/api/data/openaip/{z}/{x}/{y}.png?apiKey={PF_OPENAIPKEY}").addTo(map);
+    var openaip_cached_basemap = new L.TileLayer("https://{s}.api.tiles.openaip.net/api/data/openaip/{z}/{x}/{y}.png?apiKey=$OPENAIPKEY").addTo(map);
 
 EOF
 fi

--- a/rootfs/usr/share/planefence/planeheat.sh
+++ b/rootfs/usr/share/planefence/planeheat.sh
@@ -348,7 +348,9 @@ EOF
 if [[ "$OPENAIP_LAYER" == "ON" ]]
 then
 	cat <<EOF >>"$PLANEHEATHTML"
-    var openaip_cached_basemap = new L.TileLayer("https://{s}.api.tiles.openaip.net/api/data/openaip/{z}/{x}/{y}.png?apiKey=$OPENAIPKEY").addTo(map);
+    var openaip_cached_basemap = new L.TileLayer("https://{s}.api.tiles.openaip.net/api/data/openaip/{z}/{x}/{y}.png?apiKey=$OPENAIPKEY", {
+        attribution: "<a href=http://www.openaip.net>OpenAIP.net</a>"
+    }).addTo(map);
 
 EOF
 fi

--- a/rootfs/usr/share/planefence/prep-planefence.sh
+++ b/rootfs/usr/share/planefence/prep-planefence.sh
@@ -288,6 +288,9 @@ configure_both "DISCORD_FEEDER_NAME" "\"${DISCORD_FEEDER_NAME}\""
 configure_both "DISCORD_MEDIA" "\"${DISCORD_MEDIA}\""
 configure_both "NOTIFICATION_SERVER" "\"NOTIFICATION_SERVER\""
 
+# Add OPENAIPKEY for use with OpenAIP, necessary for it to work if PF_OPENAIP_LAYER is ON
+configure_planefence "OPENAIPKEY" "$PF_OPENAIPKEY"
+
 # Configure Mastodon parameters:
 if [[ -n "$MASTODON_SERVER" ]] && [[ -n "$MASTODON_ACCESS_TOKEN" ]]
 then

--- a/rootfs/usr/share/planefence/stage/planefence.config
+++ b/rootfs/usr/share/planefence/stage/planefence.config
@@ -275,9 +275,10 @@ PF_SCREENSHOT_TIMEOUT=45
 #
 # ---------------------------------------------------------------------
 # When PF_OPENAIP_LAYER is set to ON, the OPENAIP layer is shown on the heatmap.
-# The map overlay would look similar to https://map.openaip.net
+# If set to ON, an OpenAIP API key must be provided as OPENAIPKEY. You can get an API key after creating an account at https://www.openaip.net
 # Default is OFF
 PF_OPENAIP_LAYER=OFF
+OPENAIPKEY=
 #
 # ---------------------------------------------------------------------
 # PF_TWEET_BEHAVIOR determines if a Planefence Tweet is sent after the initial observation or after the last observation within the Fence

--- a/rootfs/usr/share/planefence/stage/planefence.config
+++ b/rootfs/usr/share/planefence/stage/planefence.config
@@ -278,7 +278,7 @@ PF_SCREENSHOT_TIMEOUT=45
 # If set to ON, an OpenAIP API key must be provided as OPENAIPKEY. You can get an API key after creating an account at https://www.openaip.net
 # Default is OFF
 PF_OPENAIP_LAYER=OFF
-OPENAIPKEY=
+PF_OPENAIPKEY=
 #
 # ---------------------------------------------------------------------
 # PF_TWEET_BEHAVIOR determines if a Planefence Tweet is sent after the initial observation or after the last observation within the Fence

--- a/rootfs/usr/share/planefence/stage/planefence.config
+++ b/rootfs/usr/share/planefence/stage/planefence.config
@@ -275,7 +275,7 @@ PF_SCREENSHOT_TIMEOUT=45
 #
 # ---------------------------------------------------------------------
 # When PF_OPENAIP_LAYER is set to ON, the OPENAIP layer is shown on the heatmap.
-# If set to ON, an OpenAIP API key must be provided as OPENAIPKEY. You can get an API key after creating an account at https://www.openaip.net
+# If set to ON, an OpenAIP API key must be provided as PF_OPENAIPKEY. You can get an API key after creating an account at https://www.openaip.net
 # Default is OFF
 PF_OPENAIP_LAYER=OFF
 PF_OPENAIPKEY=


### PR DESCRIPTION
# Summary 
OpenAIP changed everything last year to require an API key to get their map tiles. If a Planefence user wants OpenAIP objects to appear in their Planefence heatmap, they'll need to create an account at https://openaip.net and generate an API key, then add the key to planefence.config.

# Changes
* Fixes code in `planeheat.sh` to use the new OpenAIP URL with 
* Adds `PF_OPENAIPKEY` envar to `planefence.config`; blank by default, user must populate it
* Adds an empty `OPENAIPKEY` var to `planefence.conf`
* In `prep-planefence.sh`, uses `configure_planefence` func to fill `OPENAIPKEY` with `$PF_OPENAIPKEY`

# Notes
Important to note, I haven't done an all-up test yet with all the changes above. I've just manually changed planeheat.sh within a running container, hardcoded my API key, ran the script and then checked Planefence. 

I did try both a garbage API key and a blank API key and verified it didn't set anything on fire, it just didn't display the OpenAIP layer but otherwise worked normally.

It may be a good idea to bring the dev branch up to date with main, as it's a few commits behind, and then merge this PR to dev for additional testing.

![image](https://github.com/kx1t/docker-planefence/assets/7931765/0998cf14-b32f-4e5f-9a9e-c0e7bbf5f335)
